### PR TITLE
[Feat] 멋사 스프링 7주차 과제

### DIFF
--- a/spring/week07/seminar/src/main/java/com/example/seminar/entity/Board.java
+++ b/spring/week07/seminar/src/main/java/com/example/seminar/entity/Board.java
@@ -1,0 +1,32 @@
+package com.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@ToString
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String boardName;
+
+    @OneToMany(mappedBy = "board")
+    @ToString.Exclude
+    private List<Post> posts = new ArrayList<>();
+
+    public void addPost(Post post) {
+        posts.add(post);
+        post.setBoard(this);
+    }
+}

--- a/spring/week07/seminar/src/main/java/com/example/seminar/entity/Comment.java
+++ b/spring/week07/seminar/src/main/java/com/example/seminar/entity/Comment.java
@@ -1,0 +1,30 @@
+package com.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Setter
+@ToString
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="writer_id")
+    @ToString.Exclude
+    private Writer writer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="post_id")
+    @ToString.Exclude
+    private Post post;
+
+}

--- a/spring/week07/seminar/src/main/java/com/example/seminar/entity/Post.java
+++ b/spring/week07/seminar/src/main/java/com/example/seminar/entity/Post.java
@@ -1,0 +1,41 @@
+package com.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@ToString
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    @ToString.Exclude
+    private Writer writer;
+
+    @OneToMany(mappedBy = "post")
+    @ToString.Exclude
+    private List<Comment> comments = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    @ToString.Exclude
+    private Board board;
+
+    public void addComment(Comment comment) {
+        comments.add(comment);
+        comment.setPost(this);
+    }
+}

--- a/spring/week07/seminar/src/main/java/com/example/seminar/entity/Producer.java
+++ b/spring/week07/seminar/src/main/java/com/example/seminar/entity/Producer.java
@@ -1,0 +1,31 @@
+package com.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@Table(name = "producer")
+public class Producer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String code;
+
+    private String name;
+
+    @ManyToMany
+    @ToString.Exclude
+    private List<Product> products = new ArrayList<>();
+
+    public void addProduct(Product product) { products.add(product); }
+}

--- a/spring/week07/seminar/src/main/java/com/example/seminar/entity/Writer.java
+++ b/spring/week07/seminar/src/main/java/com/example/seminar/entity/Writer.java
@@ -1,0 +1,42 @@
+package com.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@ToString
+public class Writer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "writer")
+    @ToString.Exclude
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "writer")
+    @ToString.Exclude
+    private List<Post> posts = new ArrayList<>();
+
+    public void addComment(Comment comment) {
+        comments.add(comment);
+        comment.setWriter(this);
+    }
+
+    public void addPost(Post post) {
+        posts.add(post);
+        post.setWriter(this);
+    }
+
+}
+

--- a/spring/week07/seminar/src/main/java/com/example/seminar/repository/BoardRepository.java
+++ b/spring/week07/seminar/src/main/java/com/example/seminar/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package com.example.seminar.repository;
+
+import com.example.seminar.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/spring/week07/seminar/src/main/java/com/example/seminar/repository/CommentRepository.java
+++ b/spring/week07/seminar/src/main/java/com/example/seminar/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.example.seminar.repository;
+
+import com.example.seminar.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/spring/week07/seminar/src/main/java/com/example/seminar/repository/PostRepository.java
+++ b/spring/week07/seminar/src/main/java/com/example/seminar/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.example.seminar.repository;
+
+import com.example.seminar.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/spring/week07/seminar/src/main/java/com/example/seminar/repository/WriterRepository.java
+++ b/spring/week07/seminar/src/main/java/com/example/seminar/repository/WriterRepository.java
@@ -1,0 +1,7 @@
+package com.example.seminar.repository;
+
+import com.example.seminar.entity.Writer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WriterRepository extends JpaRepository<Writer, Long> {
+}

--- a/spring/week07/seminar/src/test/java/com/example/seminar/repository/BoardRepositoryTest.java
+++ b/spring/week07/seminar/src/test/java/com/example/seminar/repository/BoardRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.example.seminar.repository;
+
+import com.example.seminar.entity.Board;
+import com.example.seminar.entity.Post;
+import com.example.seminar.entity.Writer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class BoardRepositoryTest {
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    WriterRepository writerRepository;
+
+    @Test
+    void saveAndReadTest() {
+
+        Board board = new Board();
+        board.setBoardName("Board 1");
+        boardRepository.save(board);
+
+        Writer writer = new Writer();
+        writer.setName("Writer 1");
+        writerRepository.save(writer);
+
+        Post post = new Post();
+        post.setContent("This is a post");
+        post.setBoard(board);
+        postRepository.save(post);
+        board.addPost(post);
+
+        Post post2 = new Post();
+        post2.setContent("This is a post2");
+        post2.setBoard(board);
+        postRepository.save(post2);
+        board.addPost(post2);
+
+        System.out.println("---- 게시판 조회 ----");
+        System.out.println("Board = " + boardRepository.findAll());
+
+        System.out.println("---- 게시판 -> 게시글 조회 ----");
+        int i = 1;
+        for (Post p : boardRepository.findById(board.getId()).get().getPosts()) {
+            System.out.println("BoardPosts " + i++ + "= " + p);
+        }
+    }
+
+}

--- a/spring/week07/seminar/src/test/java/com/example/seminar/repository/CommentRepositoryTest.java
+++ b/spring/week07/seminar/src/test/java/com/example/seminar/repository/CommentRepositoryTest.java
@@ -1,0 +1,75 @@
+package com.example.seminar.repository;
+
+import com.example.seminar.entity.Board;
+import com.example.seminar.entity.Comment;
+import com.example.seminar.entity.Post;
+import com.example.seminar.entity.Writer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class CommentRepositoryTest {
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    @Autowired
+    WriterRepository writerRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    Long commentId;
+
+    @BeforeEach
+    void setUp() {
+        Board board = new Board();
+        board.setBoardName("Board 1");
+        boardRepository.save(board);
+
+        Writer writer = new Writer();
+        writer.setName("Writer 1");
+        writerRepository.save(writer);
+
+        Post post = new Post();
+        post.setContent("This is a post");
+        post.setBoard(board);
+        postRepository.save(post);
+        board.addPost(post);
+
+        Comment comment = new Comment();
+        comment.setContent("This is a comment");
+        comment.setPost(post);
+        comment.setWriter(writer);
+        Comment savedComment = commentRepository.save(comment);
+        commentId = savedComment.getId();
+
+        post.addComment(comment);
+
+        writer.addComment(comment);
+        writer.addPost(post);
+    }
+
+    @Test
+    void saveAndReadTest() {
+
+        System.out.println("---- 댓글 조회 ----");
+        System.out.println("Comment = " + commentRepository.findAll());
+
+        System.out.println("---- 댓글 -> 게시글 조회 ----");
+        System.out.println("CommentPost = " + commentRepository.findById(commentId).get().getPost());
+
+        System.out.println("---- 댓글 -> 작성자 조회 ----");
+        System.out.println("CommentWriter = " + commentRepository.findById(commentId).get().getWriter());
+
+    }
+}

--- a/spring/week07/seminar/src/test/java/com/example/seminar/repository/PostRepositoryTest.java
+++ b/spring/week07/seminar/src/test/java/com/example/seminar/repository/PostRepositoryTest.java
@@ -1,0 +1,90 @@
+package com.example.seminar.repository;
+
+import com.example.seminar.entity.Board;
+import com.example.seminar.entity.Comment;
+import com.example.seminar.entity.Post;
+import com.example.seminar.entity.Writer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class PostRepositoryTest {
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    WriterRepository writerRepository;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    Long postId;
+
+    @BeforeEach
+    void setUp() {
+        Board board = new Board();
+        board.setBoardName("Board 1");
+        boardRepository.save(board);
+
+        Writer writer = new Writer();
+        writer.setName("Writer 1");
+        writerRepository.save(writer);
+
+        Post post = new Post();
+        post.setContent("This is a post");
+        post.setBoard(board);
+        Post savedPost = postRepository.save(post);
+        board.addPost(post);
+        postId = savedPost.getId();
+
+        Comment comment = new Comment();
+        comment.setContent("This is a comment");
+        comment.setPost(post);
+        comment.setWriter(writer);
+        commentRepository.save(comment);
+
+        Comment comment2 = new Comment();
+        comment2.setContent("This is a comment2");
+        comment2.setPost(post);
+        comment2.setWriter(writer);
+        commentRepository.save(comment2);
+
+        post.addComment(comment);
+        post.addComment(comment2);
+
+        writer.addComment(comment);
+        writer.addComment(comment2);
+        writer.addPost(post);
+    }
+
+    @Test
+    void saveAndReadTest() {
+
+        System.out.println("---- 게시글 조회 ----");
+        System.out.println("Post = " + postRepository.findAll());
+
+        System.out.println("---- 게시글 -> 게시판 조회 ----");
+        System.out.println("PostBoard = " + postRepository.findById(postId).get().getBoard());
+
+        System.out.println("---- 게시글 -> 작성자 조회 ----");
+        System.out.println("PostWriter = " + postRepository.findById(postId).get().getWriter());
+
+        System.out.println("---- 게시글 -> 댓글 조회 ----");
+        int i = 1;
+        for (Comment c : postRepository.findById(postId).get().getComments()) {
+            System.out.println("PostComment " + i++ + "= " + c);
+        }
+
+    }
+
+}

--- a/spring/week07/seminar/src/test/java/com/example/seminar/repository/WriterRepositoryTest.java
+++ b/spring/week07/seminar/src/test/java/com/example/seminar/repository/WriterRepositoryTest.java
@@ -1,0 +1,90 @@
+package com.example.seminar.repository;
+
+import com.example.seminar.entity.Board;
+import com.example.seminar.entity.Comment;
+import com.example.seminar.entity.Post;
+import com.example.seminar.entity.Writer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class WriterRepositoryTest {
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    WriterRepository writerRepository;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    Long writerId;
+
+    @BeforeEach
+    void setUp() {
+        Board board = new Board();
+        board.setBoardName("Board 1");
+        boardRepository.save(board);
+
+        Writer writer = new Writer();
+        writer.setName("Writer 1");
+        Writer savedWriter = writerRepository.save(writer);
+        writerId = savedWriter.getId();
+
+        Post post = new Post();
+        post.setContent("This is a post");
+        post.setBoard(board);
+        postRepository.save(post);
+        board.addPost(post);
+
+        Comment comment = new Comment();
+        comment.setContent("This is a comment");
+        comment.setPost(post);
+        comment.setWriter(writer);
+        commentRepository.save(comment);
+
+        Comment comment2 = new Comment();
+        comment2.setContent("This is a comment2");
+        comment2.setPost(post);
+        comment2.setWriter(writer);
+        commentRepository.save(comment2);
+
+        post.addComment(comment);
+        post.addComment(comment2);
+
+        writer.addComment(comment);
+        writer.addComment(comment2);
+        writer.addPost(post);
+    }
+
+    @Test
+    void saveAndReadTest() {
+
+        System.out.println("---- 작성자 조회 ----");
+        System.out.println("Writer = " + writerRepository.findAll());
+
+        System.out.println("---- 작성자 -> 게시글 조회 ----");
+        int i = 1;
+        for (Post p : writerRepository.findById(writerId).get().getPosts()) {
+            System.out.println("WriterPost " + i++ + "= " + p);
+        }
+
+        System.out.println("---- 작성자 -> 댓글 조회 ----");
+        int j = 1;
+        for (Comment c : writerRepository.findById(writerId).get().getComments()) {
+            System.out.println("WriterComment " + j++ + "= " + c);
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #49 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
### Board, Post, Writer, Comment 엔티티 매핑 구현
- **간단한 ERD 설계**

   <img width="599" height="344" alt="ERD" src="https://github.com/user-attachments/assets/fa3a44a7-ca01-4ddc-86cb-8c8a65dce02b" />
- **Post ↔ Board**
  
    하나의 게시판에는 여러 개의 게시글이 올라올 수 있고, 하나의 게시글은 하나의 게시판에 속함
    
    → Board 테이블 입장에서는 일대다, Post 테이블 입장에서는 다대일
```java
// Post
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "board_id")
    @ToString.Exclude
    private Board board;
// Board
    @OneToMany(mappedBy = "board")
    @ToString.Exclude
    private List<Post> posts = new ArrayList<>();
```

- **Post ↔ Comment**
    
    하나의 게시글에는 여러 개의 댓글이 추가될 수 있고, 하나의 댓글은 하나의 게시글에 속함
    
    → Post 테이블 입장에서는 일대다, Comment 테이블 입장에서는 다대일
```java
// Post
    @OneToMany(mappedBy = "post")
    @ToString.Exclude
    private List<Comment> comments = new ArrayList<>();
// Comment
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name="post_id")
    @ToString.Exclude
    private Post post;
```

- **Post ↔ Writer**
    
    하나의 작성자는 여러 개의 게시글을 작성할 수 있고, 하나의 게시글은 하나의 작성자에 속함
    
    → Writer 테이블 입장에서는 일대다, Post 테이블 입장에서는 다대일
```java
// Post
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "writer_id")
    @ToString.Exclude
    private Writer writer;
// Writer
    @OneToMany(mappedBy = "writer")
    @ToString.Exclude
    private List<Post> posts = new ArrayList<>();
```

- **Comment ↔ Writer**
    
    하나의 작성자는 여러 개의 댓글을 작성할 수 있고, 하나의 댓글은 하나의 작성자에 속함
    
    → Writer 테이블 입장에서는 일대다, Comment 테이블 입장에서는 다대일
```java
// Comment
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name="writer_id")
    @ToString.Exclude
    private Writer writer;
// Writer
    @OneToMany(mappedBy = "writer")
    @ToString.Exclude
    private List<Comment> comments = new ArrayList<>();
```

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="305" height="84" alt="BoardRepositoryTest" src="https://github.com/user-attachments/assets/e0960fe7-e402-4086-9198-746cca416df2" />

게시판, 게시판 -> 게시글 조회 테스트<br/>
<img width="377" height="119" alt="WriterRepositoryTest" src="https://github.com/user-attachments/assets/39d0dbd5-ec95-4e30-9ddd-b44a3ecd220e" />
작성자, 작성자 -> 댓글, 작성자 -> 게시글 조회 테스트<br/>
<img width="386" height="152" alt="PostRepositoryTest" src="https://github.com/user-attachments/assets/4551f106-69e3-4008-9647-f4c33b42fa95" />
게시글, 게시글 -> 작성자, 게시글 -> 댓글, 게시글 -> 게시판 조회 테스트<br/>
<img width="382" height="102" alt="CommentRepositoryTest" src="https://github.com/user-attachments/assets/186fe0ee-7a34-4bda-9265-0ebe774485b3" />
댓글, 댓글 -> 작성자, 댓글 -> 게시글 조회 테스트<br/>

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
### LazyInitializationException 해결방법
failed to lazily initialize a collection of role: com.example.seminar.entity.Board.posts: could not initialize proxy - no Session
org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: com.example.seminar.entity.Board.posts: could not initialize proxy - no Session

**원인**
Board 엔티티 안의 Post를 지연로딩으로 지정해놨음
-> board 객체는 조회했지만 그 안의 posts 리스트는 로딩되지 않았고, 지연 로딩하려고 보니 세션이 이미 종료되어있어서 못 불러옴
@Transactional이 없으면 레포지토리에서 findById를 하면 세션이 열리고 board 엔티티를 반환한 후 트랜잭션이 바로 끝나며 세션이 닫힘 → 이후 getPost()로 접근 시 오류<br/>
**해결**
테스트 클래스에 @Tansactional 붙이기