### PR TITLE
[Feat] 멋사 스프링 8주차 과제

### DIFF
--- a/spring/week08/seminar/src/main/java/com/example/seminar/controller/UserController.java
+++ b/spring/week08/seminar/src/main/java/com/example/seminar/controller/UserController.java
@@ -1,0 +1,26 @@
+package com.example.seminar.controller;
+
+import com.example.seminar.dto.SignupRequestDto;
+import com.example.seminar.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<?> signUp(@Valid @RequestBody SignupRequestDto signupRequestDto) {
+        userService.signUp(signupRequestDto);
+        return ResponseEntity.ok("회원가입이 정상적으로 완료되었습니다.");
+    }
+
+}

--- a/spring/week08/seminar/src/main/java/com/example/seminar/dto/SignupRequestDto.java
+++ b/spring/week08/seminar/src/main/java/com/example/seminar/dto/SignupRequestDto.java
@@ -1,0 +1,28 @@
+package com.example.seminar.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class SignupRequestDto {
+
+    @NotBlank
+    @Size(max = 20, message = "아이디는 20자 이하여야 합니다.")
+    private String username;
+
+    @NotBlank
+    @Email(message = "잘못된 이메일 형식입니다.")
+    @Size(max = 50, message = "이메일은 50자 이하여야 합니다.")
+    private String email;
+
+    @NotBlank
+    @Size(min = 8, max = 20)
+    private String password1;
+
+    @NotBlank
+    @Size(min = 8, max = 20)
+    private String password2;
+
+}

--- a/spring/week08/seminar/src/main/java/com/example/seminar/entity/User.java
+++ b/spring/week08/seminar/src/main/java/com/example/seminar/entity/User.java
@@ -1,0 +1,28 @@
+package com.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 20)
+    private String username;
+
+    @Column(nullable = false, length = 50)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+}

--- a/spring/week08/seminar/src/main/java/com/example/seminar/exception/CustomException.java
+++ b/spring/week08/seminar/src/main/java/com/example/seminar/exception/CustomException.java
@@ -9,6 +9,11 @@ public class CustomException extends RuntimeException {
         this.httpStatus = httpStatus;
     }
 
+    public CustomException(HttpStatus httpStatus) {
+        super(httpStatus.getMessage());
+        this.httpStatus = httpStatus;
+    }
+
     public CustomException(HttpStatus httpStatus, String message, Throwable cause) {
         super(message, cause);
         this.httpStatus = httpStatus;

--- a/spring/week08/seminar/src/main/java/com/example/seminar/exception/GlobalExceptionHandler.java
+++ b/spring/week08/seminar/src/main/java/com/example/seminar/exception/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.example.seminar.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(CustomExceptionHandler.class);
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> methodArgumentNotValidException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+
+        String field = ex.getBindingResult().getFieldErrors().get(0).getField();
+        String message = ex.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
+
+        LOGGER.error("Advice 내 methodArgumentNotValidException 호출, URI: {}, 메시지: {}",
+                request.getRequestURI(), message);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("error type", HttpStatus.BAD_REQUEST.getMessage());
+        map.put("code", Integer.toString(HttpStatus.BAD_REQUEST.getCode()));
+        map.put("message", message);
+        map.put("error field", field);
+
+        return ResponseEntity.status(400)
+                .body(map);
+
+    }
+
+}

--- a/spring/week08/seminar/src/main/java/com/example/seminar/exception/HttpStatus.java
+++ b/spring/week08/seminar/src/main/java/com/example/seminar/exception/HttpStatus.java
@@ -8,8 +8,11 @@ public enum HttpStatus {
     FORBIDDEN(403, "Forbidden"),
     NOT_FOUND(404, "Not Found"),
     INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
-    SERVICE_UNAVAILABLE(503, "Service Unavailable");
+    SERVICE_UNAVAILABLE(503, "Service Unavailable"),
     // 추가로 커스텀 에러도 작성 가능 ex. INVALID_TOKEN
+    USERNAME_DUPLICATED(409, "Username Already Exists"),
+    INVALID_EMAIL_DOMAIN(400, "Invalid Email Domain"),
+    PASSWORD_CONFIRM_MISMATCH(400, "Password Confirm Mismatch");
 
     private final int code;
     private final String message;

--- a/spring/week08/seminar/src/main/java/com/example/seminar/repository/UserRepository.java
+++ b/spring/week08/seminar/src/main/java/com/example/seminar/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.example.seminar.repository;
+
+import com.example.seminar.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByUsername(String username);
+}

--- a/spring/week08/seminar/src/main/java/com/example/seminar/service/UserService.java
+++ b/spring/week08/seminar/src/main/java/com/example/seminar/service/UserService.java
@@ -1,0 +1,42 @@
+package com.example.seminar.service;
+
+import com.example.seminar.dto.SignupRequestDto;
+import com.example.seminar.entity.User;
+import com.example.seminar.exception.CustomException;
+import com.example.seminar.exception.HttpStatus;
+import com.example.seminar.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void signUp(SignupRequestDto signupRequestDto) {
+
+        String username = signupRequestDto.getUsername();
+        if (userRepository.existsByUsername(username))
+            throw new CustomException(HttpStatus.USERNAME_DUPLICATED);
+
+        String email = signupRequestDto.getEmail();
+        if (!email.endsWith("@sookmyung.ac.kr"))
+            throw new CustomException(HttpStatus.INVALID_EMAIL_DOMAIN);
+
+        String password1 = signupRequestDto.getPassword1();
+        String password2 = signupRequestDto.getPassword2();
+        if (!password1.equals(password2))
+            throw new CustomException(HttpStatus.PASSWORD_CONFIRM_MISMATCH);
+
+        User user = User.builder()
+                .username(username)
+                .email(email)
+                .password(password1).build();
+
+        userRepository.save(user);
+
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #52 

## ✨ 과제 내용
## Controller 단에서 @Valid 어노테이션으로 입력값 검증 수행
```
    @PostMapping("/sign-up")
    public ResponseEntity<?> signUp(@Valid @RequestBody SignupRequestDto signupRequestDto) { ... }
```

```

@Data
public class SignupRequestDto {

    @NotBlank
    @Size(max = 20, message = "아이디는 20자 이하여야 합니다.")
    private String username;

    @NotBlank
    @Email(message = "잘못된 이메일 형식입니다.")
    @Size(max = 50, message = "이메일은 50자 이하여야 합니다.")
    private String email;

    @NotBlank
    @Size(min = 8, max = 20)
    private String password1;

    @NotBlank
    @Size(min = 8, max = 20)
    private String password2;

}
```

> **NotBlank vs NotEmpty vs NotNull 차이**
> - **NotNull** - null만 허용 X, "" (빈 문자열), " " (공백 문자열)은 통과
> - **NotEmpty** - null과 빈 문자열 허용 X, 공백 문자열은 통과
> - **NotBlank** - null, 빈 문자열, 공백 문자열 모두 허용 X

- username, email, password1, password2 모두 @ NotBlank로 null, 빈 문자열, 공백 문자열까지 허용 X
- @Email로 이메일 형식 유효성 검증
- @ Size로 필드 길이 제한

-> 검증 실패 시 ⚠️**MethodArgumentNotValidException** 발생

### MethodArgumentNotValidException 핸들러 추가
- MethodArgumentNotValidException에 대한 핸들러를 추가하지 않은 경우
<img width="1725" height="611" alt="image" src="https://github.com/user-attachments/assets/e64ded04-c4f0-4a38-a4da-946005accad7" />
메시지가 너무 복잡하고, 응답 형식도 통일되지 않음<br>
<br>

-> GlobalExceptionHandler에 MethodArgumentNotValidException 핸들러 추가
```
    @ExceptionHandler(MethodArgumentNotValidException.class)
    public ResponseEntity<?> methodArgumentNotValidException(MethodArgumentNotValidException ex, HttpServletRequest request) {

        String field = ex.getBindingResult().getFieldErrors().get(0).getField();
        String message = ex.getBindingResult().getFieldErrors().get(0).getDefaultMessage();

        LOGGER.error("Advice 내 methodArgumentNotValidException 호출, URI: {}, 메시지: {}",
                request.getRequestURI(), message);

        Map<String, String> map = new HashMap<>();
        map.put("error type", HttpStatus.BAD_REQUEST.getMessage());
        map.put("code", Integer.toString(HttpStatus.BAD_REQUEST.getCode()));
        map.put("message", message);
        map.put("error field", field);

        return ResponseEntity.status(400)
                .body(map);

    }
```
복잡한 메시지가 아닌 핵심 메시지만 가져오기 위해 `ex.getBindingResult().getFieldErrors().get(0).getDefaultMessage();`
( 여러 필드 에러들 중 **첫 번째 에러의 메시지**만 가져옴 )
Map에 field 키값쌍을 넣어 **어떤 필드에서 유효성 검증에 실패했는지**도 확인 가능하도록 함!


<br/>

## Service 단에서의 예외 처리
✔️ **CustomException에 message가 필요없는 생성자 추가**
   HttpStatus에서 디폴트 메시지를 설정해놓았기 때문에 CustomException을 throw 할 때 또 메시지를 설정할 필요 없이 HttpStatus만 인자로 전달하도록 함 / 메시지 별도 설정이 필요할 경우 message도 인자로 전달하는 생성자 사용

1. `userRepository.existsByUsername()`을 통해 SignupRequestDto의 username이 이미 존재하는지 확인
-> 존재할 경우 `throw new CustomException(HttpStatus.USERNAME_DUPLICATED);`
3. `email.endsWith("@sookmyung.ac.kr")`를 통해 @sookmyung.ac.kr로 끝나는지 체크 후, 그렇지 않으면 `throw new CustomException(HttpStatus.INVALID_EMAIL_DOMAIN);`
4. `password1.equals(password2)`를 통해 비밀번호와 확인용 비밀번호가 일치하는지 체크 후, 일치하지 않으면 `throw new CustomException(HttpStatus.PASSWORD_CONFIRM_MISMATCH);`
5. 모든 검사를 통과 시 User 객체 생성 후 `userRepository.save(user);`
6. CustomException 발생 시 CustomExceptionHandler에 의해 error type, code, message 반환


<br/>
<br/>

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="913" height="389" alt="회원가입 성공" src="https://github.com/user-attachments/assets/56450dc8-ef1f-4fba-82f5-ebe735c0bb15" />
회원가입 성공

<img width="913" height="438" alt="중복 아이디" src="https://github.com/user-attachments/assets/0c8f4385-14fb-4977-8c1f-17d4da292dd9" />
아이디가 중복된 경우

<img width="916" height="434" alt="올바르지 않은 이메일 도메인" src="https://github.com/user-attachments/assets/0b1f24d0-e780-4ab8-a55d-f4e8fbe622e1" />
이메일이 @sookmyung.ac.kr로 끝나지 않은 경우

<img width="917" height="437" alt="비밀번호 불일치" src="https://github.com/user-attachments/assets/01546653-6edb-43fd-921d-9c46b654458e" />
비밀번호와 확인용 비밀번호가 일치하지 않는 경우

<img width="917" height="452" alt="잘못된 이메일 형식" src="https://github.com/user-attachments/assets/ae093896-824b-4559-b0f9-9ffd56add94b" />
잘못된 이메일 형식으로 유효성 검사에 실패한 경우

<img width="916" height="449" alt="공백" src="https://github.com/user-attachments/assets/747dfd3a-6f8c-4884-8f80-3f8659818707" />
아이디 값을 공백으로 넣어 유효성 검사에 실패한 경우

<img width="911" height="457" alt="이메일 공백" src="https://github.com/user-attachments/assets/00951673-8fcd-4da7-af37-ea7c6fe5acf9" />
이메일 값을 공백으로 넣어 유효성 검사에 실패한 경우

<img width="915" height="454" alt="비밀번호 길이" src="https://github.com/user-attachments/assets/2549e640-3ac4-4655-9b7f-2d2ef6dd6eee" />
잘못된 비밀번호 길이로 유효성 검사에 실패한 경우

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
여러 필드가 @Valid를 통한 유효성 검사에서 실패한 경우, BindingResult.getFieldErrors() 리스트에 여러 개의 field error가 쌓인다는 것을 알게 되었다.
<img width="909" height="446" alt="image" src="https://github.com/user-attachments/assets/024c1000-2392-4bf8-b67d-f8ee3665607e" />
또한 이 테스트 결과를 보면 username과 email 모두 검증 실패하는 경우임에도 get(0)했을 때 username이 아닌 email에 대한 field error가 먼저 출력이 되었다. getFieldErrors() 리스트에는 검증기가 순차적으로 필드를 검사하는 순서대로 들어가는데, 보통 DTO에 선언한 필드 순서대로 들어가지만 100% 보장되지는 않는다. 그렇기 때문에 DTO에 username을 먼저 선언했음에도 get(0)했을 때 email에 대한 field error가 출력될 수 있음을 알게 되었다.
